### PR TITLE
Refactor: Consolidate navigation links into '文档'

### DIFF
--- a/html/report.html
+++ b/html/report.html
@@ -37,13 +37,7 @@
                         <a class="nav-link" href="../index.html">主页</a>
                     </li>
                     <li>
-                        <a class="nav-link" target="_blank" href="https://docs.qq.com/doc/DZUNTc1BtaW5oc21B">指南</a>
-                    </li>
-                    <li>
-                        <a class="nav-link" href="rules.html">规则</a>
-                    </li>
-                    <li>
-                        <a class="nav-link" href="report.html"><b>工单</b></a>
+                        <a class="nav-link" target="_blank" href="https://flowus.cn/cubex/share/077c8f04-bc13-4708-b72b-0b196d315e35?code=U2NN84">文档</a>
                     </li>
                     <li>
                         <a class="nav-link" target="_blank" href="https://afdian.com/@cubex">捐款</a>

--- a/html/rules.html
+++ b/html/rules.html
@@ -37,13 +37,7 @@
                         <a class="nav-link" href="../index.html" style="text-shadow: 1px 1px 1px rgb(0,0,0,0.5)">主页</a>
                     </li>
                     <li>
-                        <a class="nav-link" target="_blank" href="https://docs.qq.com/doc/DZUNTc1BtaW5oc21B">指南</a>
-                    </li>
-                    <li>
-                        <a class="nav-link" href="rules.html" style="color:white; text-shadow: 1px 1px 1px rgb(0,0,0,0.5)"><b>规则</b></a>
-                    </li>
-                    <li>
-                        <a class="nav-link" href="report.html" style="text-shadow: 1px 1px 1px rgb(0,0,0,0.5)">工单</a>
+                        <a class="nav-link" target="_blank" href="https://flowus.cn/cubex/share/077c8f04-bc13-4708-b72b-0b196d315e35?code=U2NN84" style="text-shadow: 1px 1px 1px rgb(0,0,0,0.5)">文档</a>
                     </li>
                     <li>
                         <a class="nav-link" target="_blank" href="https://afdian.com/@cubex" style="text-shadow: 1px 1px 1px rgb(0,0,0,0.5)">捐款</a>

--- a/index.html
+++ b/index.html
@@ -34,13 +34,7 @@
                         <a class="nav-link" href="index.html"><b>主页</b></a>
                     </li>
                     <li>
-                        <a class="nav-link" target="_blank" href="https://docs.qq.com/doc/DZUNTc1BtaW5oc21B">指南</a>
-                    </li>
-                    <li>
-                        <a class="nav-link" href="html/rules.html">规则</a>
-                    </li>
-                    <li>
-                        <a class="nav-link" href="html/report.html">工单</a>
+                        <a class="nav-link" target="_blank" href="https://flowus.cn/cubex/share/077c8f04-bc13-4708-b72b-0b196d315e35?code=U2NN84">文档</a>
                     </li>
                     <li>
                         <a class="nav-link" target="_blank" href="https://afdian.com/@cubex">捐款</a>


### PR DESCRIPTION
Merged '指南', '规则', and '工单' into a single '文档' link in the navigation bar across index.html, html/report.html, and html/rules.html.

The new '文档' link points to: https://flowus.cn/cubex/share/077c8f04-bc13-4708-b72b-0b196d315e35?code=U2NN84